### PR TITLE
feat: add GET /health endpoint

### DIFF
--- a/workshop-project/app/main.py
+++ b/workshop-project/app/main.py
@@ -4,3 +4,8 @@ from app.routers import users
 app = FastAPI(title="Workshop API", version="1.0.0")
 
 app.include_router(users.router, prefix="/users", tags=["users"])
+
+
+@app.get("/health")
+async def health_check():
+    return {"status": "ok", "version": app.version}

--- a/workshop-project/tests/test_health.py
+++ b/workshop-project/tests/test_health.py
@@ -1,0 +1,15 @@
+async def test_health_returns_200(client):
+    response = await client.get("/health")
+    assert response.status_code == 200
+
+
+async def test_health_response_body(client):
+    response = await client.get("/health")
+    assert response.json() == {"status": "ok", "version": "1.0.0"}
+
+
+async def test_health_works_with_empty_db(client):
+    # DB is empty (reset by autouse fixture) — endpoint must still respond
+    response = await client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "version": "1.0.0"}


### PR DESCRIPTION
## Summary

Implements the health check endpoint described in #1.

- Added `GET /health` directly in `app/main.py` (not in a router)
- Returns `{"status": "ok", "version": "1.0.0"}` — version sourced from `app.version`
- No database calls; responds in well under 50ms

## Tests

Three new tests in `tests/test_health.py`:
- `test_health_returns_200` — verifies HTTP 200 response
- `test_health_response_body` — verifies exact JSON body
- `test_health_works_with_empty_db` — verifies endpoint works with empty users DB

All 12 tests pass (9 existing + 3 new).

Closes #1