### PR TITLE
Add CORS configuration

### DIFF
--- a/workshop-project/app/main.py
+++ b/workshop-project/app/main.py
@@ -1,7 +1,16 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from app.routers import users
 
 app = FastAPI(title="Workshop API", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000", "http://localhost:5173"],
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"],
+)
 
 app.include_router(users.router, prefix="/users", tags=["users"])
 

--- a/workshop-project/tests/test_cors.py
+++ b/workshop-project/tests/test_cors.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+async def test_cors_preflight_returns_200(client):
+    response = await client.options(
+        "/users",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code == 200
+
+
+async def test_cors_allowed_origin_header(client):
+    response = await client.get("/users", headers={"Origin": "http://localhost:3000"})
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+async def test_cors_disallowed_origin_no_header(client):
+    response = await client.get("/users", headers={"Origin": "http://evil.com"})
+    assert "access-control-allow-origin" not in response.headers


### PR DESCRIPTION
## What was implemented

- Added `CORSMiddleware` to `app/main.py` before router registration
- Allowed origins: `http://localhost:3000` and `http://localhost:5173` (Vite default)
- Allowed methods: `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`
- Allowed headers: `Content-Type`, `Authorization`
- `allow_credentials` set to `True`
- No new dependencies required (CORSMiddleware is built into Starlette)

## Tests added

New file `tests/test_cors.py`:
- OPTIONS preflight to `/users` returns 200
- Request from `http://localhost:3000` includes `Access-Control-Allow-Origin: http://localhost:3000`
- Request from disallowed origin does NOT receive the `Access-Control-Allow-Origin` header

All 15 tests pass.

Closes #106