### PR TITLE
Add input validation for POST /users and PUT /users/{id}

### DIFF
--- a/workshop-project/app/models.py
+++ b/workshop-project/app/models.py
@@ -1,16 +1,16 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr, Field
 
 
 class UserCreate(BaseModel):
-    name: str
-    email: str
-    age: int
+    name: str = Field(..., min_length=1)
+    email: EmailStr
+    age: int = Field(..., ge=0, le=150)
 
 
 class UserUpdate(BaseModel):
-    name: str | None = None
-    email: str | None = None
-    age: int | None = None
+    name: str | None = Field(default=None, min_length=1)
+    email: EmailStr | None = None
+    age: int | None = Field(default=None, ge=0, le=150)
 
 
 class UserResponse(BaseModel):

--- a/workshop-project/pyproject.toml
+++ b/workshop-project/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi==0.115.0",
     "uvicorn[standard]==0.30.6",
-    "pydantic==2.8.0",
+    "pydantic[email]==2.8.0",
 ]
 
 [dependency-groups]

--- a/workshop-project/tests/test_users.py
+++ b/workshop-project/tests/test_users.py
@@ -58,3 +58,34 @@ async def test_delete_user(client):
 async def test_delete_user_not_found(client):
     response = await client.delete("/users/999")
     assert response.status_code == 404
+
+
+async def test_create_user_invalid_email(client):
+    response = await client.post("/users", json={"name": "Alice", "email": "not-an-email", "age": 30})
+    assert response.status_code == 422
+
+
+async def test_create_user_negative_age(client):
+    response = await client.post("/users", json={"name": "Alice", "email": "alice@example.com", "age": -1})
+    assert response.status_code == 422
+
+
+async def test_create_user_age_too_high(client):
+    response = await client.post("/users", json={"name": "Alice", "email": "alice@example.com", "age": 151})
+    assert response.status_code == 422
+
+
+async def test_create_user_empty_name(client):
+    response = await client.post("/users", json={"name": "", "email": "alice@example.com", "age": 30})
+    assert response.status_code == 422
+
+
+async def test_create_user_valid(client):
+    response = await client.post("/users", json={"name": "Alice", "email": "alice@example.com", "age": 30})
+    assert response.status_code == 201
+
+
+async def test_update_user_invalid_email(client):
+    await client.post("/users", json={"name": "Alice", "email": "alice@example.com", "age": 30})
+    response = await client.put("/users/1", json={"email": "not-an-email"})
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Use `pydantic.EmailStr` for email validation (returns 422 for invalid emails)
- Add `Field(ge=0, le=150)` constraint on `age` field
- Add `Field(min_length=1)` constraint on `name` field to reject empty strings
- Add `pydantic[email]` to `pyproject.toml` for `email-validator` package
- Validation applies to both `POST /users` and `PUT /users/{id}`
- Added 6 new tests covering all validation edge cases

Closes #3

## Test plan
- [ ] `POST /users` with `email: "not-an-email"` → 422
- [ ] `POST /users` with `age: -1` → 422
- [ ] `POST /users` with `age: 151` → 422
- [ ] `POST /users` with `name: ""` → 422
- [ ] `POST /users` with valid data → 201
- [ ] `PUT /users/{id}` with invalid email → 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)