### PR TITLE
Add response compression

### DIFF
--- a/workshop-project/app/main.py
+++ b/workshop-project/app/main.py
@@ -1,7 +1,12 @@
 from fastapi import FastAPI
+from fastapi.middleware.gzip import GZipMiddleware
 from app.routers import users
 
+GZIP_MINIMUM_SIZE = 1000
+
 app = FastAPI(title="Workshop API", version="1.0.0")
+
+app.add_middleware(GZipMiddleware, minimum_size=GZIP_MINIMUM_SIZE)
 
 app.include_router(users.router, prefix="/users", tags=["users"])
 

--- a/workshop-project/pyproject.toml
+++ b/workshop-project/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "fastapi==0.115.0",
     "uvicorn[standard]==0.30.6",
     "pydantic==2.8.0",
+    "email-validator>=2.3.0",
 ]
 
 [dependency-groups]

--- a/workshop-project/tests/test_compression.py
+++ b/workshop-project/tests/test_compression.py
@@ -1,0 +1,64 @@
+from app import database
+
+
+async def test_large_response_is_gzipped(client):
+    for i in range(50):
+        database.users_db[i] = {
+            "id": i,
+            "name": f"User{i}",
+            "email": f"user{i}@example.com",
+            "age": 20 + (i % 50),
+        }
+
+    response = await client.get("/users", headers={"Accept-Encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.headers.get("content-encoding") == "gzip"
+    assert len(response.json()) == 50
+
+
+async def test_small_response_is_not_gzipped(client):
+    response = await client.get("/users", headers={"Accept-Encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.headers.get("content-encoding") is None
+    assert response.json() == []
+
+
+async def test_client_without_gzip_accept_gets_uncompressed(client):
+    for i in range(50):
+        database.users_db[i] = {
+            "id": i,
+            "name": f"User{i}",
+            "email": f"user{i}@example.com",
+            "age": 20 + (i % 50),
+        }
+
+    response = await client.get("/users", headers={"Accept-Encoding": "identity"})
+    assert response.status_code == 200
+    assert response.headers.get("content-encoding") is None
+    assert len(response.json()) == 50
+
+
+async def test_existing_crud_still_works_after_middleware(client):
+    create_resp = await client.post(
+        "/users",
+        json={"name": "Alice", "email": "alice@example.com", "age": 30},
+    )
+    assert create_resp.status_code == 201
+    user_id = create_resp.json()["id"]
+
+    get_resp = await client.get(f"/users/{user_id}")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["name"] == "Alice"
+
+    put_resp = await client.put(f"/users/{user_id}", json={"name": "Alice Updated"})
+    assert put_resp.status_code == 200
+    assert put_resp.json()["name"] == "Alice Updated"
+
+    delete_resp = await client.delete(f"/users/{user_id}")
+    assert delete_resp.status_code == 204
+
+
+async def test_health_endpoint_returns_correct_data(client):
+    response = await client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "version": "1.0.0"}

--- a/workshop-project/uv.lock
+++ b/workshop-project/uv.lock
@@ -59,6 +59,28 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.115.0"
 source = { registry = "https://pypi.org/simple" }
@@ -576,6 +598,7 @@ name = "workshop-api"
 version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "pydantic" },
     { name = "uvicorn", extra = ["standard"] },
@@ -591,6 +614,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = "==0.115.0" },
     { name = "pydantic", specifier = "==2.8.0" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.30.6" },


### PR DESCRIPTION
## Summary
- Register `GZipMiddleware` in `app/main.py` with `GZIP_MINIMUM_SIZE = 1000`, placed before `include_router(...)` so all routes are wrapped.
- Add `tests/test_compression.py` with 5 tests covering large/small payloads, `Accept-Encoding: identity` behavior, and a CRUD smoke test through the middleware.
- Add `email-validator` to dependencies — required by `EmailStr` in `app/models.py` so the existing test suite can import.

## Acceptance criteria
- [x] GZip enabled for responses > 1000 bytes
- [x] Uses `GZipMiddleware` from `fastapi.middleware.gzip`
- [x] `GZIP_MINIMUM_SIZE = 1000` defined at top of `app/main.py`
- [x] Existing endpoints still return correct JSON
- [x] Clients without `Accept-Encoding: gzip` receive uncompressed responses

## Test plan
- [x] `uv run pytest -v` — 29 passed (24 existing + 5 new)
- [x] `GET /users` with 50 users + `Accept-Encoding: gzip` → `Content-Encoding: gzip`
- [x] `GET /users` empty → no `Content-Encoding` header
- [x] `GET /users` with 50 users + `Accept-Encoding: identity` → no `Content-Encoding`

Closes #7